### PR TITLE
Fixes `method_missing': undefined local variable or method `options' for...

### DIFF
--- a/lib/recipes/data_sync.rb
+++ b/lib/recipes/data_sync.rb
@@ -52,7 +52,7 @@ Capistrano::Configuration.instance.load do
   desc "Downloads the files in public/system"
   task :download_files, :roles => :db, :only => { :primary => true } do
     `mkdir -p public/system`
-    execute_on_servers(options) do |servers|
+    execute_on_servers do |servers|
       logger.info "Pulling public/system via rsync"
       `rsync --delete -r #{user}@#{servers.first}:#{deploy_to}/#{current_dir}/public/system/* public/system`
     end


### PR DESCRIPTION
... #Capistrano::Configuration:... (NameError)

Did this "options" argument have any value or can I remove it ?

I just realized my production capistrano version is 2.11.2 (but I cannot update it without contacting my server host) so maybe it could be related.

Thanks for the gem btw, really userful :)
